### PR TITLE
[Leo] Fix su command to support optional password when privilege higher

### DIFF
--- a/src/account.cpp
+++ b/src/account.cpp
@@ -176,6 +176,12 @@ int AccountSystem::getCurrentPrivilege() const {
     return loginStack.top().privilege;
 }
 
+// Get privilege of a specific account
+int AccountSystem::getAccountPrivilege(const std::string& userID) const {
+    if (!accountExists(userID)) return -1;
+    return accounts.at(userID).privilege;
+}
+
 // Check if someone is logged in
 bool AccountSystem::isLoggedIn() const {
     return !loginStack.empty();
@@ -206,9 +212,17 @@ bool AccountSystem::su(const std::string& userID, const std::string& password) {
         return false;
     }
     
-    // Verify password
-    if (accounts[userID].password != password) {
-        return false;
+    // Check if password is required
+    // Password can be omitted if current privilege > target privilege
+    int currentPriv = getCurrentPrivilege();
+    int targetPriv = accounts[userID].privilege;
+    bool passwordRequired = (currentPriv <= targetPriv);
+    
+    // If password is required (or provided), verify it
+    if (passwordRequired || !password.empty()) {
+        if (accounts[userID].password != password) {
+            return false;
+        }
     }
     
     // Create new login session and push onto stack

--- a/src/account.h
+++ b/src/account.h
@@ -71,6 +71,7 @@ public:
     
     // Privilege and state queries
     int getCurrentPrivilege() const;
+    int getAccountPrivilege(const std::string& userID) const;
     bool isLoggedIn() const;
     std::string getCurrentSelectedBook() const;
     void setSelectedBook(const std::string& isbn);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -68,11 +68,20 @@ int main() {
         
         // Handle su command
         // Syntax: su [UserID] [Password]
+        // Password can be omitted if current privilege > target privilege
         if (command == "su") {
             std::string userID, password;
-            ss >> userID >> password;
+            ss >> userID;
             
-            if (userID.empty() || password.empty()) {
+            // Read password if provided (might be empty)
+            if (ss >> password) {
+                // Password was provided
+            } else {
+                // Password was not provided - set to empty
+                password = "";
+            }
+            
+            if (userID.empty()) {
                 std::cout << "Invalid" << std::endl;
                 continue;
             }


### PR DESCRIPTION
Fixes issue #10

## Changes
- Added getAccountPrivilege() helper to AccountSystem
- Modified su() to allow password omission when current privilege > target privilege
- Updated main.cpp su command parsing to accept 1 or 2 parameters

## Testing
- Test 210 line 6 (su rbq without password) now succeeds
- Test 210 output changed from 6 Invalid to 4 Invalid (expected)
- Backward compatible: password still required when privilege <= target
- Tests 1, 2, 3, 10 still pass

## Implementation
Password bypass logic:
- Current privilege > target privilege → password optional
- Current privilege ≤ target privilege → password required
- When password provided, always validated

Ready for review.