### PR TITLE
[Leo] Fix quit/exit validation (M5.1 BUG #1)

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -72,6 +72,10 @@ int main() {
         
         // Handle quit and exit commands
         if (command == "quit" || command == "exit") {
+            std::string extra;
+            if (ss >> extra) {
+                std::cout << "Invalid" << std::endl;
+            }
             break;
         }
         


### PR DESCRIPTION
## Summary
Fix M5.1 BUG #1: quit/exit commands now validate extra arguments and output 'Invalid' when extra args are provided.

## Changes
- Added extra argument validation for quit and exit commands in src/main.cpp
- Commands now check for trailing arguments after the command
- Outputs 'Invalid' and exits if extra arguments are present

## Testing
All test cases verified:
- ✅ `quit extra` → outputs 'Invalid' then exits
- ✅ `exit extra` → outputs 'Invalid' then exits
- ✅ `quit arg1 arg2` → outputs 'Invalid' then exits
- ✅ `quit` → exits with no output (correct behavior)
- ✅ `exit` → exits with no output (correct behavior)

## Risk Assessment
Low risk - minimal change, doesn't affect normal quit/exit behavior