### PR TITLE
[Maya] Fix show multi-parameter validation (M5.1 BUG #2)

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -560,6 +560,7 @@ int main() {
                 std::string paramName = remaining.substr(1, eqPos - 1);
                 size_t valueStart = eqPos + 1;
                 std::string paramValue;
+                size_t paramEndPos = 0;  // Track where the first parameter ends
                 
                 // Parse value (quoted or unquoted)
                 if (valueStart < remaining.length() && remaining[valueStart] == '"') {
@@ -571,6 +572,7 @@ int main() {
                         continue;
                     }
                     paramValue = remaining.substr(valueStart, closeQuote - valueStart);
+                    paramEndPos = closeQuote + 1;  // Position after closing quote
                 } else {
                     // Unquoted value - read until space or end
                     size_t endPos = valueStart;
@@ -578,12 +580,24 @@ int main() {
                         endPos++;
                     }
                     paramValue = remaining.substr(valueStart, endPos - valueStart);
+                    paramEndPos = endPos;  // Position after last character of value
                 }
                 
                 // Check if parameter value is empty
                 if (paramValue.empty()) {
                     std::cout << "Invalid" << std::endl;
                     continue;
+                }
+                
+                // Check for multiple parameters (spec violation - only ONE parameter allowed)
+                if (paramEndPos < remaining.length()) {
+                    // Check if there's non-whitespace content after the first parameter
+                    std::string afterFirst = remaining.substr(paramEndPos);
+                    size_t firstNonSpace = afterFirst.find_first_not_of(" \t");
+                    if (firstNonSpace != std::string::npos) {
+                        std::cout << "Invalid" << std::endl;
+                        continue;
+                    }
                 }
                 
                 // Execute search based on parameter


### PR DESCRIPTION
Fixes issue #85

This PR fixes the critical spec violation where the `show` command was accepting multiple filter parameters instead of rejecting them per spec R71.

**Problem:**
- `show -ISBN=A -name="B"` was succeeding instead of returning "Invalid"
- Spec R71 states that show should only accept ONE filter parameter

**Solution:**
- Added validation after parsing the first parameter
- Track `paramEndPos` to know where the first parameter ends
- Check if there's any non-whitespace content after the first parameter
- If yes, output "Invalid" instead of executing the search

**Testing:**
✓ `show -ISBN=A -name="BookA"` → Invalid
✓ `show -name="BookA" -ISBN=A` → Invalid  
✓ `show -ISBN=A -author="AuthorA"` → Invalid
✓ `show -keyword=key1 -name="BookA"` → Invalid
✓ `show -ISBN=A` (single param) → works correctly
✓ `show -name="BookA"` (single param) → works correctly
✓ `show` (no params) → shows all books
✓ `show -ISBN=A   ` (trailing whitespace) → works correctly

This fixes one of the three critical bugs in M5.1 milestone.