### PR TITLE
[Noah] Add try-catch blocks to loadFinance() for malformed data handling

### DIFF
--- a/src/book.cpp
+++ b/src/book.cpp
@@ -159,11 +159,19 @@ void BookSystem::loadFinance() {
         std::string typeStr = line.substr(0, pipePos);
         std::string amountStr = line.substr(pipePos + 1);
         
-        int typeInt = std::stoi(typeStr);
-        double amount = std::stod(amountStr);
-        
-        FinanceRecord::Type type = (typeInt == 0) ? FinanceRecord::INCOME : FinanceRecord::EXPENSE;
-        financeRecords.push_back(FinanceRecord(type, amount));
+        try {
+            int typeInt = std::stoi(typeStr);
+            double amount = std::stod(amountStr);
+            
+            FinanceRecord::Type type = (typeInt == 0) ? FinanceRecord::INCOME : FinanceRecord::EXPENSE;
+            financeRecords.push_back(FinanceRecord(type, amount));
+        } catch (const std::invalid_argument& e) {
+            // Skip malformed line - invalid number format
+            continue;
+        } catch (const std::out_of_range& e) {
+            // Skip malformed line - number out of range
+            continue;
+        }
     }
     
     infile.close();


### PR DESCRIPTION
## Summary
Fixes issue #117

## Changes
- Added try-catch blocks around `std::stoi` and `std::stod` calls in `loadFinance()` function
- Handles `std::invalid_argument` and `std::out_of_range` exceptions
- Skips malformed lines and continues loading valid finance data
- Prevents SIGABRT crashes when encountering corrupted finance.txt

## Testing
Created and ran comprehensive tests with:
- Invalid number formats (abc, not_a_number)
- Out-of-range values (999999999999999999999999999999)
- Missing pipe separators
- Valid data mixed with malformed data

All tests passed - program no longer crashes with malformed data.