### PR TITLE
[Maya] Fix issue #123: Add overflow check to importBook()

### DIFF
--- a/src/book.cpp
+++ b/src/book.cpp
@@ -4,6 +4,7 @@
 #include <vector>
 #include <iomanip>
 #include <iostream>
+#include <climits>
 
 const std::string BookSystem::BOOKS_FILE = "books.dat";
 const std::string BookSystem::FINANCE_FILE = "transactions.dat";
@@ -508,6 +509,11 @@ bool BookSystem::importBook(const std::string& ISBN, int quantity, double totalC
     }
     
     Book* book = &(it->second);
+    
+    // Check for overflow before adding quantity
+    if (book->quantity > INT_MAX - quantity) {
+        return false;
+    }
     
     // Increase quantity
     book->quantity += quantity;


### PR DESCRIPTION
## Summary
Fixes issue #123: Added overflow protection to the importBook() function to prevent signed integer overflow when accumulating book quantities.

## Changes
1. Added `#include <climits>` to src/book.cpp (line 7)
2. Added overflow check before quantity accumulation (lines 513-516):
   ```cpp
   // Check for overflow before adding quantity
   if (book->quantity > INT_MAX - quantity) {
       return false;
   }
   ```

## Technical Details
- Uses the mathematical property: `a + b > INT_MAX` ⟺ `a > INT_MAX - b`
- Check is performed BEFORE the addition to prevent undefined behavior
- Returns false to gracefully reject operations that would overflow
- INT_MAX = 2,147,483,647

## Testing
- ✅ Unit tests: All 4 test cases passed
- ✅ Integration tests: Overflow correctly rejected
- ✅ Compilation: No warnings or errors
- ✅ Normal import operations: Still work correctly

## Files Changed
- src/book.cpp: 6 insertions (1 include, 5 overflow check lines)

Ready for review and merge.