### PR TITLE
[Maya] Fix issue #132: Add inf/nan validation in modify command price parsing

### DIFF
--- a/src/main.cpp
+++ b/src/main.cpp
@@ -4,6 +4,7 @@
 #include <vector>
 #include <algorithm>
 #include <iomanip>
+#include <cmath>
 #include "account.h"
 #include "book.h"
 
@@ -439,7 +440,7 @@ int main() {
                     }
                     try {
                         newPrice = std::stod(paramValue);
-                        if (newPrice < 0) {
+                        if (!std::isfinite(newPrice) || newPrice < 0) {
                             parseError = true;
                             break;
                         }


### PR DESCRIPTION
## Summary
This PR adds validation to reject inf/nan values in the modify command's price parsing.

## Changes
1. Added `#include <cmath>` header to src/main.cpp (line 7)
2. Added validation check at line 443: `if (!std::isfinite(newPrice) || newPrice < 0)`

## Implementation
After `std::stod(paramValue)` converts the price string at line 442, the code now validates that:
- The value is finite (not inf or nan) using `std::isfinite()`
- The value is non-negative (`>= 0`)

If either check fails, parseError is set to true and the modify command returns "Invalid".

## Testing
Verified with test cases:
- `modify -price=100.00` → Success (price updates correctly)
- `modify -price=inf` → Invalid (price unchanged)
- `modify -price=nan` → Invalid (price unchanged)
- `modify -price=-inf` → Invalid (price unchanged)

Fixes #132